### PR TITLE
Added mobile mod. Tweaked base theme core style. Many changes.

### DIFF
--- a/Game_Modding.md
+++ b/Game_Modding.md
@@ -1,18 +1,27 @@
-# Custom Game Maps
+---
+layout: default
+title: Custom Game Maps
+---
 
-# [Timerborn](https://store.steampowered.com/app/1062090/Timberborn/){:target="_blank"}
+# Game Modding
+
+## Timerborn
+[![Download](assets/images/icon-download.svg){:class='icon icon-download'}](https://store.steampowered.com/app/1062090/Timberborn/){:target="_blank"}
+[Steam Store](https://store.steampowered.com/app/1062090/Timberborn/){:target="_blank"}
+
 - A game about a post human world where beavers are now the domenant species
 - The player builds a town with farms, industry, homes and entertainments in the goal to have a thriving community with a high well being score
 - Typical game loop is alternating seasons of temperate where water flows and everything is nice then flips to either a drought or a bad tide
 	- In a drought water stops flowing from sources and starts receading
 	- In a bad tide water sources start pumping bad water (toxic waste) which kills plants and makes your beavers sick on contact
 
-<br>
+---
 
-## [Red Tide Islands](https://mod.io/g/timberborn/m/red-tide-islands){:target="_blank"}
+## Red Tide Islands
+[![Download](assets/images/icon-download.svg){:class='icon icon-download'}](https://mod.io/g/timberborn/m/red-tide-islands){:target="_blank"}
+[Mod.io Download](https://mod.io/g/timberborn/m/red-tide-islands){:target="_blank"}
+
 ![Red_Tide_Island](assets/images/Red_Tide_Island.PNG)
-
-<br>
 
 ### Map Layout
 - 1) Your starting area
@@ -34,8 +43,6 @@
 	- Mid game opportunity for scrap metal harvesting from ruins
 	- A underground entrance for a late game scrap metal mine
 
-<br>
-
 ### The Challenge
 - This is an opposite approach map which flips the [typical scenerio](https://timberborn.fandom.com/wiki/Maps) upside down
  - Typical maps are land locked with a shallow river running through it to provide horsepower for water wheels and water dries up during a drought
@@ -44,18 +51,16 @@
 	- However, when a bad tide season comes the map is now flooded with bad water that tends to stick around after the season inceasing toxicity around you
 	- This is a play on to much of a good thing and water water everywhere but not a drop to drink
 
-<br>
-
 ### Design Choices
 - A challenging map different that its competitors on 3rd party sites
 - Water is unusually ubundant but becomes a primary antagonist in the maps progression
 - Progression:
-	- Early Game: 
+	- Early Game:
 		- Abundant resources and well telegraphed build spots
-	- Mid Game: 
+	- Mid Game:
 		- Insentivising islands nearby to expand to in range of your central district but pushing the limits
 		- Playes will experience their first bad tide and realise this map isnt as easy as one thought and a whole new problem is revealed when the bad water doesnt disipate easily
-	- Late Game: 
+	- Late Game:
 		- Multiple districts are required for shortage of land and high travel distances
 		- Logistics setup will be needed for trade between the islands
 		- Water toxicity is quite high and solutions need to be implemented to protect anyting on a coast line

--- a/Scripts.md
+++ b/Scripts.md
@@ -1,7 +1,14 @@
+---
+layout: default
+title: Scripts
+---
+
 # Scripts
 
-## [Delete Meta Files](https://github.com/Fenris42/Delete_Meta_Files){:target="_blank"}
-* Language: Powershell
+## Delete Meta Files
+[![Download](assets/images/icon-download.svg){:class='icon icon-download'}](https://github.com/Fenris42/Delete_Meta_Files){:target="_blank"}
+[Github Repository](https://github.com/Fenris42/Delete_Meta_Files){:target="_blank"}  
+**Language:** Powershell
 
 ![Delete_Meta_Files](assets/images/Delete_Meta_Files.PNG)
 

--- a/Unity_Projects.md
+++ b/Unity_Projects.md
@@ -1,11 +1,16 @@
-# Unity Projects
-* Disclaimer: Games are not for selling or distribution. All artwork are placeholders as I am not an artist and just experimenting with game development   
- 
-<br>
-<br>
+---
+layout: default
+title: Unity Projects
+---
 
-## Project Rock Hopper (Private)
-* Status: Active
+# Unity Projects
+
+<div class="callout">
+  <strong>Disclaimer:</strong> Games are not for selling or distribution. All artwork are placeholders as I am not an artist and just experimenting with game development   
+</div>
+
+## Project Rock Hopper
+**Status:** Active
 
 ![RockHopper](assets/images/project_rock_hopper.png)
 A 2D asteroid mining game
@@ -14,44 +19,47 @@ A 2D asteroid mining game
 * Dont run out of life support (Health, Oxygen, Energy, Fuel)
 * You feel like you might not be alone
 
-<br>
-<br>
+---
 
-## [Project Forest (Public)](https://github.com/Fenris42/Project_Forest){:target="_blank"}
-* Status: Shelved
+## Project Forest
+**Status:** Shelved  
+[![Download](assets/images/icon-download.svg){:class='icon icon-download'}](https://github.com/Fenris42/Project_Forest){:target="_blank"}
+[Github Repository](https://github.com/Fenris42/Project_Forest){:target="_blank"}
 
 ![Forest](assets/images/project_forest.png)
 A top down dungeon crawler RPG
 * Implemented mob AI for multiple class configurations, player tracking and targeting solutions
 
-<br>
-<br>
+---
 
-## [Project Sebastion (Public)](https://github.com/Fenris42/Project_Sebastion){:target="_blank"}
-* Status: Shelved
+## Project Sebastion
+**Status:** Shelved  
+[![Download](assets/images/icon-download.svg){:class='icon icon-download'}](https://github.com/Fenris42/Project_Sebastion){:target="_blank"}
+[Github Repository](https://github.com/Fenris42/Project_Sebastion){:target="_blank"}
 
 ![Sebastion](assets/images/project_sebastion.png)
 A lane based protect the tower game
 * Wave based enemies
 * Resource drop on mob death
 
-<br>
-<br>
+---
 
-## [2D Game Experiment (Public)](https://github.com/Fenris42/2D_Platformer_Experiment){:target="_blank"}
-* Status: Complete
+## 2D Game Experiment
+**Status:** Complete  
+[![Download](assets/images/icon-download.svg){:class='icon icon-download'}](https://github.com/Fenris42/2D_Platformer_Experiment){:target="_blank"}
+[Github Repository](https://github.com/Fenris42/2D_Platformer_Experiment){:target="_blank"}
 
 ![2D_Experiment](assets/images/2d_experiment.png)
-My first indipendent game where I was experimenting with implementing a variety of common game systems in preperation to start a real attempt at making a game.
+My first indipendent game where I was experimenting with implementing a variety of common game systems in preparation to start a real attempt at making a game.
 
-<br>
-<br>
+---
 
-## [Flappy Borb (Public)](https://github.com/Fenris42/Flappy_Borb){:target="_blank"}
-* Status: Complete
+## Flappy Borb
+**Status:** Complete  
+[![Download](assets/images/icon-download.svg){:class='icon icon-download'}](https://github.com/Fenris42/Flappy_Borb){:target="_blank"}
+[Github Repository](https://github.com/Fenris42/Flappy_Borb){:target="_blank"}
 
 ![FlappyBorb](assets/images/flappy_borb.png)
 My very first Unity project and attempt at game developement
 * Followed tutorial [The Unity Tutorial For Complete Beginners](https://youtu.be/XtQMytORBmM?si=leTh6QheRjBX62GI)
-* Continued experimenting after tutorial with a a life system and 3 lives
-
+* Continued experimenting after tutorial with a life system and 3 lives

--- a/_config.yml
+++ b/_config.yml
@@ -1,5 +1,5 @@
-title: Fenris42.GitHub.io
-description: Matt Todd's Project Page
+# title: Fenris42.GitHub.io
+description: Matt Todd's Project&nbsp;Page
 remote_theme: pages-themes/hacker@v0.2.0
 plugins:
 - jekyll-remote-theme

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -5,38 +5,44 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="stylesheet" href="{{ '/assets/css/style.css?v=' | append: site.github.build_revision | relative_url }}">
-	
-	<!-- Fav Icon -->
-	<link rel="shortcut icon" type="image/x-icon" href="assets/images/favicon.png">
-	
+
+    <!-- Fav Icon -->
+    <link rel="shortcut icon" type="image/x-icon" href="assets/images/favicon.png">
+
     {% include head-custom.html %}
-	{% seo %}
+    {% seo %}
   </head>
 
   <body>
     <header>
-      <div class="container">
-        <a id="a-title" href="{{ '/' | relative_url }}">
-          <h1>{{ site.description | default: site.github.project_tagline }}</h1>
-		  <h2>{{ site.title | default: site.github.repository_name }}</h2>
-        </a>
-		
-		<!-- Nav Bar -->
-		<ul class="nav">
-			<li class="nav"><a class="nav" href="https://fenris42.github.io">About</a></li>
-			<li class="nav"><a class="nav" href="Unity_Projects.html">Unity Projects</a></li>
-			<li class="nav"><a class="nav" href="Game_Modding.html">Game Modding</a></li>
-			<li class="nav"><a class="nav" href="Scripts.html">Scripts</a></li>
-		</ul>
-		
-		<!-- Breadcrumb -->
-		<div style="padding-top: 10px;">
-			<a style="padding-left: 10px;" href="https://fenris42.github.io">Home</a><p id="currentPage" class="breadcrumb"></p>
-			<script src="assets/scripts/breadcrumb.js"></script>
-		</div>
-		
-		
-      </div>
+
+        <div class="identity">
+
+          <h1>
+            <a href="{{ '/' | relative_url }}">
+              {{ site.description | default: site.github.project_tagline }}
+            </a>
+          </h1>
+
+          <!-- Links -->
+          <nav class="nav-links">
+            <ul>
+              <li><a href="https://www.linkedin.com/in/matt-todd/" class="btn btn-linkedin" target="_blank"><span class="icon"></span><span class="link-text">Linkedin</a></li>
+              <li><a href="https://github.com/Fenris42" class="btn btn-github" target="_blank"><span class="icon"></span><span class="link-text">GitHub</span></a></li>
+            </ul>
+          </nav>
+
+        </div>
+
+    		<!-- Nav Bar -->
+        <nav class="nav-main">
+      		<ul>
+      			<li><a href="/">Home</a></li>
+      			<li><a href="Unity_Projects.html">Unity Projects</a></li>
+      			<li><a href="Game_Modding.html">Game Modding</a></li>
+      			<li><a href="Scripts.html">Scripts</a></li>
+      		</ul>
+        </nav>
     </header>
 
     <div class="container">
@@ -44,5 +50,8 @@
         {{ content }}
       </section>
     </div>
+
+    <script src="assets/scripts/nav.js"></script>
+
   </body>
 </html>

--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -2,51 +2,262 @@
 ---
 
 @import "{{ site.theme }}";
-.btn-linkedin .icon {
-	opacity: 0.6;
-	background: url("../images/linkedin.png") 0 0 no-repeat;
-}
-.inline{
-	display: inline-block;
-}
-.breadcrumb{
-	white-space: pre;
-	display: inline-block;
-	font-size: 16px;
-	color: #b5e853;
-	margin: 0;
-}
-ul.nav{
-	list-style-type: none;
-	margin: 0;
-	padding: 0;
-	overflow: hidden;
-	background-color: #1c1c1c;
-	display: inline-block;
-	width: 100%;
-}
-li.nav{
-	display: inline;
-	float: left;
-	border-right: 1px solid black;
-}
-a.nav{
-	display: block;
-	padding: 8px;
-	font-size: 18px;
-	text-decoration: none;
-	color: #b5e853;
-}
-a:hover.nav{
-	background: #b5e853;
-	color: #666;
-}
-header{
+
+header {
 	position: sticky;
 	top: 0;
 	width: 100%;
 	background: black;
+	z-index: 1;
 }
-body{
-	margin-bottom: 100px;
+
+header .identity {
+	padding: 30px 0;
+	width: 90%;
+	display: flex;
+	flex-direction: row;
+	justify-content: space-between;
+	max-width: 1000px;
+	margin: 0 auto;
+}
+
+header .identity h1 {
+	margin-left: -5px;
+}
+
+header .identity h1 a {
+  color: #b5e853;
+	text-decoration: none;
+}
+
+header .identity h1 a:hover {
+	text-decoration: underline;
+}
+
+header .nav-links {
+	display: flex;
+	flex-direction: row;
+	align-items: center;
+}
+
+header .nav-links ul {
+	list-style-type: none;
+	display: flex;
+	flex-direction: row;
+	justify-content: flex-end;
+	margin: 0;
+	padding: 0
+}
+
+header .nav-links ul li { list-style-image: none; }
+header .nav-links ul li a { display: flex; }
+
+header .nav-links .btn-linkedin .icon {
+	opacity: 0.8;
+	background: url("/assets/images/linkedin.png") 0 0 no-repeat;
+}
+
+header .nav-main {
+	background: #1c1c1c;
+}
+
+header .nav-main ul {
+	list-style-type: none;
+	margin: 0 auto;
+	padding: 0;
+	overflow: hidden;
+	background-color: #1c1c1c;
+	width: 90%;
+	max-width: 1000px;
+}
+
+header .nav-main ul li {
+	display: inline;
+	float: left;
+	border-right: 1px solid black;
+}
+
+header .nav-main ul li:first-child {
+	border-left: 1px solid black;
+}
+
+header .nav-main ul li a {
+	display: block;
+	padding: 8px;
+	font-size: 16px;
+	text-decoration: none;
+	color: #b5e853;
+}
+
+header .nav-main ul li a:hover {
+	background: #b5e853;
+	color: #666;
+}
+
+header .nav-main ul li a.active {
+	background: #e1f5ba;
+	color: #666;
+	pointer-events: none;
+}
+
+@media (max-width: 800px) {
+	header {
+		margin-bottom: 16px;
+	}
+
+	header .identity {
+ 	  flex-direction: column;
+	  align-items: flex-start;
+		margin: 0 auto 15px;
+		padding: 0;
+	}
+
+	header .identity h1 {
+		margin-bottom: 10px;
+		font-size: 20px;
+		font-weight: normal;
+	}
+
+  header .identity .nav-links a {
+   padding: 0;
+	 margin-right: 10px;
+  }
+
+	header .identity .nav-links .icon {
+		margin-right: 0;
+	}
+
+	header .identity .nav-links .link-text {
+		display: none;
+	}
+
+	header .nav-main ul li a {
+		font-size: 11px;
+	}
+}
+
+// General
+
+body {
+	margin-bottom: 50px;
+	font-size: 14px;
+}
+
+strong {
+	color: #b5e853;
+}
+
+img {
+	display: block;
+	margin-bottom: 20px;
+}
+
+img.icon {
+	display: inline;
+  margin: 0;
+	position: relative;
+	top: 4px;
+}
+
+hr {
+	margin-top: 40px;
+	margin-bottom: 40px;
+}
+
+.callout {
+	border: 1px solid rgba(255, 255, 255, 0.15);
+	padding: 20px 25px;
+	background: #000;
+	margin-bottom: 40px;
+}
+
+@media (max-width: 800px) {
+  body {
+		font-size: 12px;
+	}
+}
+
+// Main body
+
+#main_content h1 {
+	border-bottom: 1px dashed #b5e853;
+	padding-bottom: 10px;
+	margin-bottom: 40px;
+	position: relative;
+}
+
+#main_content h1::after {
+	content: '';
+	position: absolute;
+	bottom: 3px;
+	border-bottom: 1px dashed #b5e853;
+	left: 0;
+	right: 0;
+}
+
+#main_content > ul {
+	margin-bottom: 40px
+}
+
+#main_content > ul li {
+	margin-bottom: 15px;
+}
+
+#main_content > ul li > ul {
+  margin-top: 15px;
+}
+
+
+@media (max-width: 800px) {
+	#main_content h1 {
+		font-size: 20px;
+		margin-bottom: 25px;
+	}
+
+	#main_content h2 {
+		font-size: 18px;
+		margin-bottom: 10px;
+	}
+}
+
+// Home
+
+.container .section-profile {
+	display: grid;
+	grid-template-columns: 300px 1fr;
+	grid-gap: 15px;
+}
+
+.section-profile-photo img {
+	display: block;
+	width: 100%;
+	height: auto;
+	margin-bottom: 0;
+}
+
+.container .section-profile .section-profile-about pre {
+	margin: 0;
+	height: 100%;
+	box-sizing: border-box;
+}
+
+@media (max-width: 1000px) {
+
+  .container .section-profile {
+		display: flex;
+		flex-direction: column;
+		margin-bottom: 20px;
+  }
+
+	.container .section-profile .section-profile-photo img {
+		margin: 0 auto;
+		max-width: 200px;
+		width: 100%;
+		height: auto;
+	}
+
+  .container .section-profile .section-profile-about pre {
+		font-size: 12px;
+	}
+
 }

--- a/assets/images/icon-download.svg
+++ b/assets/images/icon-download.svg
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 20 20" fill="#b5e853">
+  <path d="M17 12v5H3v-5H1v5a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-5z"/>
+  <path d="M10 15l5-6h-4V1H9v8H5l5 6z"/>
+</svg>

--- a/assets/scripts/breadcrumb.js
+++ b/assets/scripts/breadcrumb.js
@@ -1,11 +1,35 @@
-//Get current page
-var path = "";
-var page = "";
 
-path = window.location.pathname;
-page = path.split("/").pop();
-page = page.replace(".html","");
-page = page.replace("_", " ");
+function setActiveElement () {
+	clearNav()
+	setActiveElement()
+}
+
+function clearNav() {
+	try {
+		// Get links, convert to array, clear active state
+		var linksNav = document.querySelectorAll('.nav-main a')
+		linksNav = Array.prototype.slice.call(linksNav);
+		linksNav.map(clearNavLink)
+	} catch (e) {
+		// something went bad, can't recover
+	}
+}
+
+function clearNavLink(node) {
+	node.classList.remove('active')
+}
+
+function setActiveElement () {
+	try {
+		//Get current page
+		var page = window.location.pathname.split("/").pop();
+
+		if (!page) {
+			document.querySelector('.nav-main li:first-child a').classList.add('active')
+		} else {
+			var linkActive = document.querySelector('.nav-main a[href=\'' + page + '\']')
+			linkActive.classList.add('active')
+		}
 
 //set breadcrumb to current page if not empty (assumes homepage)
 if (page != ""){

--- a/assets/scripts/nav.js
+++ b/assets/scripts/nav.js
@@ -1,0 +1,20 @@
+
+function setActiveElement () {
+	try {
+		//Get current page
+		var page = window.location.pathname.split("/").pop();
+
+		// If root, add active to first element in list
+		if (!page) {
+			document.querySelector('.nav-main li:first-child a').classList.add('active')
+		} else {
+			var linkActive = document.querySelector('.nav-main a[href=\'' + page + '\']')
+			linkActive.classList.add('active')
+		}
+
+	} catch (e) {
+		// something went bad, die quietly
+	}
+}
+
+setActiveElement()

--- a/index.md
+++ b/index.md
@@ -1,34 +1,27 @@
-<table>
-<tr>
-<td> <h1>Profile Pic</h1> </td>
-<td> <h1>About</h1> </td>
-</tr>
-<tr>
-<td> <img src="assets/images/profilepic.jpg"> </td>
-<td>
-<pre lang="csharp">
-<code>
-public class About_Me
-{
+---
+layout: default
+---
+
+<section class="section-profile">
+
+  <div class="section-profile-photo">
+    <img src="assets/images/profilepic.jpg" />
+  </div>
+  <div class="section-profile-about">
+    <pre lang="csharp">
+    <code>
+ public class About_Me
+ {
    public string Name        = "Matt Todd";
    public string Location    = "Vancouver, BC, Canada";
    public bool IsProgrammer  = true;
    public bool IsWebDesigner = false;
    public string[] Languages = {"C#", "Javascript", "Powershell"};
-}
-</code>
-</pre>
-</td>
-</tr>
-</table>
-
-# Links
-
-<div class="inline">
-	<a href="https://github.com/Fenris42" class="btn btn-github" target="_blank"><span class="icon"></span>GitHub</a>
-	<a href="https://www.linkedin.com/in/matt-todd/" class="btn btn-linkedin" target="_blank"><span class="icon"></span>Linkedin</a>
-</div>
-<br>
+ }
+    </code>
+    </pre>
+  </div>
+</section>
 
 # Bio
 IT Systems Engineer by day and Game Developer by night. I have a love of games and technology specializing in SaaS products, automation and programming. Recently started a new adventure in game development.


### PR DESCRIPTION
A lot of changes but a summary

About to Home
 - Root is Home and if it happens to be the about page, that's fine.
Removed Breadcrumb 
 - Breadcrumbs are for deeply nested sites. Use active state on menu as signifier
Home/About
 - Removed headers obvious
Moved links to header
 - Should be omnipresent
Removed Site Title 
 - Repeat of Github link and domain url. Already present.
Flipped Identity h1 and a:link
 - Semantic value
Add h1 for SEO in child pages
Tweak lists and headers spacing.
Added styling for h1 within main content.
Moved download from header to separate link.
Break up content with hr.
Added template reference to pages to front matter (needed for page generation)

Lots of other stuff mostly for responsiveness and spacing.
